### PR TITLE
Add screenshot web server

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Macaboo is a small command-line utility written in Python for macOS. It lets you
 pick a running GUI application and capture a screenshot of its first on-screen
-window.
+window. After selecting an application, it can start a small web server that
+serves the latest screenshot on demand.
 
 ## Features
 
@@ -28,13 +29,16 @@ pip install pyobjc-framework-Quartz pyobjc-framework-Cocoa
 
 ## Usage
 
-Run the tool directly after installing the package:
+Run the tool directly after installing the package. It will prompt you to select
+a running application and then start a web server on port 6222:
 
 ```bash
 python -m macaboo
+# open http://localhost:6222 in your browser
 ```
 
-You can optionally specify an output filename:
+You can optionally specify an output filename to save a single screenshot before
+the server starts:
 
 ```bash
 macaboo --output screenshot.png

--- a/macaboo/__init__.py
+++ b/macaboo/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/macaboo/cli.py
+++ b/macaboo/cli.py
@@ -10,15 +10,25 @@ from .screenshot import (
     get_first_window_of_app,
     capture_window,
 )
+from .server import serve_window
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Capture a screenshot of a running application window.")
+    parser = argparse.ArgumentParser(
+        description="Capture a screenshot of a running application window and serve it on the web."
+    )
     parser.add_argument(
         "--output",
         "-o",
         default=None,
         help="Output PNG file (default: '<AppName>.png')",
+    )
+    parser.add_argument(
+        "--port",
+        "-p",
+        type=int,
+        default=6222,
+        help="Port to serve the web page on (default: 6222)",
     )
     args = parser.parse_args(argv)
 
@@ -34,13 +44,13 @@ def main(argv: list[str] | None = None) -> int:
         print(f"No on-screen window found for {chosen_app.localizedName()}.")
         return 1
 
-    if args.output is None:
-        output_path = f"{chosen_app.localizedName()}.png"
-    else:
+    if args.output is not None:
         output_path = args.output
+        capture_window(window_info, output_path)
+        print(f"Screenshot saved to {output_path}")
 
-    capture_window(window_info, output_path)
-    print(f"Screenshot saved to {output_path}")
+    print("Starting web server. Press Ctrl+C to stop.")
+    serve_window(window_info, args.port)
     return 0
 
 

--- a/macaboo/server.py
+++ b/macaboo/server.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+"""Simple HTTP server to display screenshots."""
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from time import time
+
+from .screenshot import capture_window
+
+__all__ = ["serve_window"]
+
+
+def serve_window(window_info: dict, port: int = 6222) -> None:
+    """Start a blocking HTTP server showing screenshots of ``window_info``."""
+
+    screenshot_path = Path("latest.png")
+
+    class ScreenshotHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: D401
+            if self.path.startswith("/screenshot.png"):
+                capture_window(window_info, str(screenshot_path))
+                try:
+                    data = screenshot_path.read_bytes()
+                except FileNotFoundError:
+                    self.send_error(404)
+                    return
+                self.send_response(200)
+                self.send_header("Content-Type", "image/png")
+                self.send_header("Cache-Control", "no-cache, no-store, must-revalidate")
+                self.end_headers()
+                self.wfile.write(data)
+            else:
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html")
+                self.send_header("Cache-Control", "no-cache, no-store, must-revalidate")
+                self.end_headers()
+                ts = int(time())
+                html = (
+                    f"<html><body>"
+                    f"<img src='/screenshot.png?{ts}' alt='screenshot'/>"
+                    f"</body></html>"
+                )
+                self.wfile.write(html.encode("utf-8"))
+
+    server = HTTPServer(("0.0.0.0", port), ScreenshotHandler)
+    print(f"Serving on http://localhost:{port}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "macaboo"
-version = "0.1.0"
+version = "0.2.0"
 description = "CLI utilities for capturing macOS application windows"
 authors = [ { name="Macaboo" } ]
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- add a `server` module that runs an HTTP server for dynamic screenshots
- update CLI to start the server and allow specifying port
- bump version to 0.2.0
- document how to view live screenshots from a browser

## Testing
- `python -m py_compile $(git ls-files '*.py') && echo OK`