### PR TITLE
Add perceptual hash sync

### DIFF
--- a/macaboo/server.py
+++ b/macaboo/server.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 """Async HTTP server to display screenshots."""
 
 import asyncio
-import hashlib
-import threading
-import time
 from pathlib import Path
 
 from aiohttp import web, WSMsgType
@@ -22,15 +19,15 @@ TEMPLATE_PATH = Path(__file__).parent / "templates" / "index.html"
 
 class ScreenshotMonitor:
     """Monitors screenshot changes and notifies WebSocket client."""
-    
+
     def __init__(self, window_info: dict, change_threshold: float = 0.01, debug: bool = False):
         self.window_info = window_info
         self.change_threshold = change_threshold
         self.debug = debug
-        self.previous_frame = None
         self.current_screenshot = None
         self.client_ws = None
         self.monitor_task = None
+        self.last_client_hash = None
         
     def set_client(self, ws):
         """Set the WebSocket client to receive updates."""
@@ -64,23 +61,32 @@ class ScreenshotMonitor:
         nparr = np.frombuffer(screenshot_bytes, np.uint8)
         frame = cv2.imdecode(nparr, cv2.IMREAD_COLOR)
         return frame
+
+    def _compute_hash(self, screenshot_bytes: bytes) -> str:
+        """Return a simple average hash for the screenshot."""
+        nparr = np.frombuffer(screenshot_bytes, np.uint8)
+        img = cv2.imdecode(nparr, cv2.IMREAD_GRAYSCALE)
+        img = cv2.resize(img, (16, 16), interpolation=cv2.INTER_AREA)
+        avg = img.mean()
+        diff = img > avg
+        bits = ''.join('1' if b else '0' for b in diff.flatten())
+        return hex(int(bits, 2))[2:].rjust(64, '0')
         
     async def _monitor_loop(self):
         """Async loop that checks for screenshot changes."""
         while True:
             try:
                 screenshot_bytes = capture_window_bytes(self.window_info)
-                current_frame = self._bytes_to_frame(screenshot_bytes)
-                
-                if self.previous_frame is None:
+                current_hash = self._compute_hash(screenshot_bytes)
+
+                if self.last_client_hash is None:
                     if self.debug:
                         print("First screenshot captured")
-                elif self._has_significant_change(self.previous_frame, current_frame):
+                elif current_hash != self.last_client_hash:
                     await self._notify_client()
                     if self.debug:
-                        print("Screenshot change detected, notifying client")
+                        print("Screenshot hash mismatch, notifying client")
 
-                self.previous_frame = current_frame
                 self.current_screenshot = screenshot_bytes
                     
             except Exception as e:
@@ -102,8 +108,6 @@ class ScreenshotMonitor:
         """Force capture and send screenshot update to client."""
         try:
             screenshot_bytes = capture_window_bytes(self.window_info)
-            current_frame = self._bytes_to_frame(screenshot_bytes)
-            self.previous_frame = current_frame
             self.current_screenshot = screenshot_bytes
             await self._notify_client()
         except Exception as e:
@@ -156,7 +160,11 @@ def serve_window(window_info: dict, port: int = 6222, change_threshold: float = 
                         data = json.loads(msg.data)
                         event_type = data.get("type")
                         
-                        if event_type == "click":
+                        if event_type == "hash":
+                            monitor.last_client_hash = str(data.get("hash"))
+                            await ws.send_str(json.dumps({"status": "ok", "type": "hash"}))
+
+                        elif event_type == "click":
                             x = int(data.get("x", 0))
                             y = int(data.get("y", 0))
                             display_width = int(data.get("displayWidth", 0))

--- a/macaboo/templates/index.html
+++ b/macaboo/templates/index.html
@@ -56,6 +56,33 @@
   </div>
   <script>
     let ws = null;
+
+    function computeHash(img) {
+      const size = 16;
+      const canvas = document.createElement('canvas');
+      canvas.width = size;
+      canvas.height = size;
+      const ctx = canvas.getContext('2d');
+      ctx.drawImage(img, 0, 0, size, size);
+      const data = ctx.getImageData(0, 0, size, size).data;
+      const grays = [];
+      for (let i = 0; i < data.length; i += 4) {
+        const r = data[i];
+        const g = data[i + 1];
+        const b = data[i + 2];
+        grays.push(0.299 * r + 0.587 * g + 0.114 * b);
+      }
+      const avg = grays.reduce((a, b) => a + b, 0) / grays.length;
+      let bits = '';
+      for (const g of grays) {
+        bits += g > avg ? '1' : '0';
+      }
+      let hex = '';
+      for (let i = 0; i < bits.length; i += 4) {
+        hex += parseInt(bits.substr(i, 4), 2).toString(16);
+      }
+      return hex.padStart(64, '0');
+    }
     
     function showError() {
       document.getElementById('shot').style.display = 'none';
@@ -73,6 +100,12 @@
     
     function reload() {
       const img = document.getElementById('shot');
+      img.onload = function() {
+        const hash = computeHash(img);
+        if (ws && ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: 'hash', hash: hash }));
+        }
+      };
       img.src = '/screenshot.png?' + Date.now();
     }
     


### PR DESCRIPTION
## Summary
- compute 16x16 perceptual hash in server and client
- cache client's hash on the server and notify when mismatched
- send hash from the browser whenever an image loads

## Testing
- `python -m py_compile macaboo/*.py`