### PR TITLE
Improve packaging metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,74 @@
 # Macaboo
 
-Macaboo is a small command-line utility written in Python for macOS. It lets you
-pick a running GUI application and capture a screenshot of its first on-screen
-window. After selecting an application, it can start a small web server that
-serves the latest screenshot on demand.
+**Macaboo** is a small Python utility for macOS that mirrors any running GUI
+application to a browser window. It captures screenshots of an application's
+frontmost window and exposes them via a lightweight web server. The page also
+forwards mouse and keyboard events back to the application so you can interact
+with it remotely.
 
 ## Features
 
-- Lists all running GUI applications
-- Prompts you to select which app to capture
-- Saves a PNG image of the selected application's window
+- Discover running applications and choose one interactively
+- Live screenshot streaming via a local HTTP server
+- Mouse clicks, scrolling and key presses sent from the browser
+- Simple command line interface available as `macaboo`
 
 ## Requirements
 
 - macOS 10.15 or later
-- Python 3.9 or newer
-- PyObjC libraries (`pyobjc-framework-Quartz`, `pyobjc-framework-Cocoa`)
-- `aiohttp` for the built-in web server
+- Python 3.9+
+- `pyobjc-framework-Quartz` and `pyobjc-framework-Cocoa`
+- `aiohttp`, `opencv-python` and `numpy`
 
 ## Installation
 
-Create a virtual environment and install dependencies:
+Once published on PyPI the package can be installed with pip:
 
 ```bash
-python3 -m venv venv
-source venv/bin/activate
-pip install pyobjc-framework-Quartz pyobjc-framework-Cocoa aiohttp
+python -m pip install macaboo
 ```
 
-## Usage
-
-Run the tool directly after installing the package. It will prompt you to select
-a running application and then start a web server on port 6222:
+The `macaboo` command will then be available on your PATH. If you are working
+from a clone of the repository you can install an editable copy instead:
 
 ```bash
-python -m macaboo
+python -m pip install -e .
+```
+
+## Quick start
+
+Run `macaboo` with no arguments to select an application from the list of running
+processes. The default web server listens on port `6222`:
+
+```bash
+macaboo
 # open http://localhost:6222 in your browser
 ```
 
-You can optionally specify an output filename to save a single screenshot before
-the server starts:
+You can provide the application name directly or change the port:
 
 ```bash
-macaboo --output screenshot.png
+macaboo "Safari" --port 7000
 ```
+
+When the browser is open you can click, scroll and type in the screenshot just as
+if you were using the application locally.
+
+## Development
+
+The project is packaged with a standard `pyproject.toml`. After cloning, install
+the dependencies and an editable build:
+
+```bash
+python -m pip install -e .
+```
+
+On macOS this will also fetch the PyObjC and OpenCV libraries required for
+runtime operation.
+
+The source code and issue tracker live on [GitHub](https://github.com/quartzjer/macaboo).
 
 ## License
 
-This project is licensed under the Apache 2.0 License. See the
+This project is licensed under the Apache 2.0 license. See the
 [LICENSE](LICENSE) file for details.

--- a/macaboo/__init__.py
+++ b/macaboo/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.2.0"
+__version__ = "0.2.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,15 +4,23 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "macaboo"
-version = "0.2.0"
+version = "0.2.2"
 description = "CLI utilities for capturing macOS application windows"
 authors = [ { name="Macaboo" } ]
+readme = "README.md"
+license = { file = "LICENSE" }
 requires-python = ">=3.9"
 dependencies = [
     "pyobjc-framework-Quartz",
     "pyobjc-framework-Cocoa",
     "aiohttp",
+    "opencv-python",
+    "numpy",
 ]
 
 [project.scripts]
 macaboo = "macaboo.cli:main"
+
+[project.urls]
+Homepage = "https://github.com/quartzjer/macaboo"
+Repository = "https://github.com/quartzjer/macaboo"


### PR DESCRIPTION
## Summary
- list all runtime dependencies including opencv and numpy
- bump version to 0.2.2
- update GitHub links for quartzjer
- mention GitHub repo in README

## Testing
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=42)*
